### PR TITLE
autoconf: Fix C99 compatibility issue in the VA_COPY checks

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -400,6 +400,7 @@ AC_MSG_CHECKING(for an implementation of va_copy())
 AC_CACHE_VAL(slrn_cv_va_copy,[
 	AC_RUN_IFELSE([AC_LANG_SOURCE([[
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);
@@ -420,6 +421,7 @@ AC_MSG_CHECKING(for an implementation of __va_copy())
 AC_CACHE_VAL(slrn_cv___va_copy,[
 	AC_RUN_IFELSE([AC_LANG_SOURCE([[
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);
@@ -440,6 +442,7 @@ AC_MSG_CHECKING(whether va_lists can be copied by value)
 AC_CACHE_VAL(slrn_cv_va_val_copy,[
 	AC_RUN_IFELSE([AC_LANG_SOURCE([[
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);

--- a/configure
+++ b/configure
@@ -8581,6 +8581,7 @@ else
 /* end confdefs.h.  */
 
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);
@@ -8626,6 +8627,7 @@ else
 /* end confdefs.h.  */
 
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);
@@ -8671,6 +8673,7 @@ else
 /* end confdefs.h.  */
 
 	#include <stdarg.h>
+	#include <stdlib.h>
 	void f (int i, ...) {
 	va_list args1, args2;
 	va_start (args1, i);


### PR DESCRIPTION
The exit function is called without including <stdlib.h>, resulting in an implicit function declarations.  Future compilers will not support implicit function declarations by default.  This will lead to build failures.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
